### PR TITLE
Check that signatureMask isn't an empty array

### DIFF
--- a/digitalassetlinks/src/main/java/com/solana/digitalassetlinks/AndroidAppPackageVerifier.java
+++ b/digitalassetlinks/src/main/java/com/solana/digitalassetlinks/AndroidAppPackageVerifier.java
@@ -95,6 +95,10 @@ public class AndroidAppPackageVerifier extends URISourceVerifier {
             requireAllSignatures = true;
         }
 
+        if (signatureMask.length == 0) {
+            throw new CouldNotVerifyPackageException("Failed reading signatures for package " + packageName);
+        }
+
         // Create and configure an AssetLinksJSONParser object
         final StatementMatcher androidAppMatcher = StatementMatcher
                 .createAndroidAppStatementMatcher(

--- a/digitalassetlinks/src/test/java/com/solana/digitalassetlinks/AndroidAppPackageVerifierUnitTests.java
+++ b/digitalassetlinks/src/test/java/com/solana/digitalassetlinks/AndroidAppPackageVerifierUnitTests.java
@@ -223,11 +223,8 @@ public class AndroidAppPackageVerifierUnitTests {
     private static PackageManager mockPackageManagerFactory(@NonNull String packageName,
                                                             @NonNull byte[][] certificates,
                                                             boolean multipleSigners) {
-        // if (certificates.length == 0) {
-        //     throw new IllegalArgumentException("at least 1 certificate required");
-        // } else if (multipleSigners && certificates.length == 1) {
-        //     throw new IllegalArgumentException("multipleSigners requires at least 2 certificates");
-        // }
+        // NOTE: empty certificates would normally be an error, but we want to exercise unit tests
+        // for this case, so allow it when constructing a mock PackageManager
 
         final PackageInfo pi = new PackageInfo();
         final int piFlags;

--- a/digitalassetlinks/src/test/java/com/solana/digitalassetlinks/AndroidAppPackageVerifierUnitTests.java
+++ b/digitalassetlinks/src/test/java/com/solana/digitalassetlinks/AndroidAppPackageVerifierUnitTests.java
@@ -70,6 +70,24 @@ public class AndroidAppPackageVerifierUnitTests {
     }
 
     @Test
+    public void testAppPackageVerificationNoCertificates() {
+        ArrayList<MockWebContentServer.Content> mockWebContent = new ArrayList<>();
+        mockWebContent.add(new MockWebContentServer.Content(
+                URI.create("https://www.test.com/.well-known/assetlinks.json"),
+                HttpURLConnection.HTTP_OK,
+                "application/json",
+                ANDROID_APP_STATEMENT_LIST_CERTS_2_3));
+
+        final PackageManager pm = mockPackageManagerFactory(
+                "com.test.sample", new byte[][] {}, true);
+
+        final AndroidAppPackageVerifierHarness verifier =
+                new AndroidAppPackageVerifierHarness(pm, mockWebContent);
+        assertThrows(AndroidAppPackageVerifier.CouldNotVerifyPackageException.class,
+                () ->verifier.verify("com.test.sample", URI.create("https://www.test.com")));
+    }
+
+    @Test
     public void testAppPackageVerificationNoAssetLinks() {
         ArrayList<MockWebContentServer.Content> mockWebContent = new ArrayList<>();
         mockWebContent.add(new MockWebContentServer.Content(
@@ -205,11 +223,11 @@ public class AndroidAppPackageVerifierUnitTests {
     private static PackageManager mockPackageManagerFactory(@NonNull String packageName,
                                                             @NonNull byte[][] certificates,
                                                             boolean multipleSigners) {
-        if (certificates.length == 0) {
-            throw new IllegalArgumentException("at least 1 certificate required");
-        } else if (multipleSigners && certificates.length == 1) {
-            throw new IllegalArgumentException("multipleSigners requires at least 2 certificates");
-        }
+        // if (certificates.length == 0) {
+        //     throw new IllegalArgumentException("at least 1 certificate required");
+        // } else if (multipleSigners && certificates.length == 1) {
+        //     throw new IllegalArgumentException("multipleSigners requires at least 2 certificates");
+        // }
 
         final PackageInfo pi = new PackageInfo();
         final int piFlags;


### PR DESCRIPTION
The `verify()` function decides whether to succeed of fail based on the result of the following code:

```java
        // Step 6: Check the verification state produced by the Android App statement matcher
        boolean result = true;
        for (boolean b : signatureMask) {
            if (!b) {
                result = false;
                break;
            }
        }

        return result;
```

If for some reason `signatureMask` turned out to be an empty array, the for loop would never be reached and`verify()` would always return true. Therefore, the verification logic could be bypassed. This change ensures that the code throws an exception in the (very unlikely) case that signatureMask is an empty array.