### PR TITLE
AGP upgrade assistant: move package namespace to build.gradle

### DIFF
--- a/digitalassetlinks/build.gradle
+++ b/digitalassetlinks/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 android {
+    namespace = 'com.solana.digitalassetlinks'
     compileSdk 33
 
     defaultConfig {

--- a/digitalassetlinks/src/main/AndroidManifest.xml
+++ b/digitalassetlinks/src/main/AndroidManifest.xml
@@ -3,8 +3,7 @@
   ~ Copyright (c) 2022 Solana Mobile Inc.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.solana.digitalassetlinks">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Uses internet permissions to fetch Asset Links files from authoritative URLs -->
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
Tested locally